### PR TITLE
fix: install links should not be pinned to an old version

### DIFF
--- a/assistants/naming-conventions/README.md
+++ b/assistants/naming-conventions/README.md
@@ -5,13 +5,13 @@
 Naming conventions used by the Sketch design team.
 
 👉 Click
-[here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-naming-conventions-assistant&version=5.0.0-next.10)
+[here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-naming-conventions-assistant)
 to add to Sketch.
 
 > Or, add to a Sketch release variant:
-> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-naming-conventions-assistant&version=5.0.0-next.10)
+> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-naming-conventions-assistant)
 > |
-> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-naming-conventions-assistant&version=5.0.0-next.10)
+> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-naming-conventions-assistant)
 > |
 > [Internal](https://add-sketch-assistant.now.sh/api/main?variant=internal&pkg=@sketch-hq/sketch-naming-conventions-assistant)
 > |

--- a/assistants/reuse-suggestions/README.md
+++ b/assistants/reuse-suggestions/README.md
@@ -6,15 +6,15 @@ Notices when similar styles and groups could be abstracted into shared styles an
 respectively.
 
 👉 Click
-[here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-reuse-suggestions-assistant&version=5.0.0-next.10)
+[here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 to add to Sketch.
 
 > Or, add to a Sketch release variant:
-> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-reuse-suggestions-assistant&version=5.0.0-next.10)
+> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 > |
-> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-reuse-suggestions-assistant&version=5.0.0-next.10)
+> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 > |
-> [Internal](https://add-sketch-assistant.now.sh/api/main?variant=internal&pkg=@sketch-hq/sketch-reuse-suggestions-assistant&version=5.0.0-next.10)
+> [Internal](https://add-sketch-assistant.now.sh/api/main?variant=internal&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 > |
 > [Experimental](https://add-sketch-assistant.now.sh/api/main?variant=experimental&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 > |

--- a/assistants/tidy/README.md
+++ b/assistants/tidy/README.md
@@ -5,16 +5,15 @@
 The rules in this Assistant are all focused on keeping your Sketch documents as clean and tidy as
 possible.
 
-👉 Click
-[here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-tidy-assistant&version=5.0.0-next.10)
+👉 Click [here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-tidy-assistant)
 to add to Sketch.
 
 > Or, add to a Sketch release variant:
-> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-tidy-assistant&version=5.0.0-next.10)
+> [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-tidy-assistant)
 > |
-> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-tidy-assistant&version=5.0.0-next.10)
+> [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-tidy-assistant)
 > |
-> [Internal](https://add-sketch-assistant.now.sh/api/main?variant=internal&pkg=@sketch-hq/sketch-tidy-assistant&version=5.0.0-next.10)
+> [Internal](https://add-sketch-assistant.now.sh/api/main?variant=internal&pkg=@sketch-hq/sketch-tidy-assistant)
 > |
 > [Experimental](https://add-sketch-assistant.now.sh/api/main?variant=experimental&pkg=@sketch-hq/sketch-tidy-assistant)
 > |

--- a/packages/cli/workspace.json
+++ b/packages/cli/workspace.json
@@ -1,7 +1,0 @@
-{
-  "dependencies": {
-    "@sketch-hq/sketch-tidy-assistant": "latest",
-    "@sketch-hq/sketch-naming-conventions-assistant": "latest",
-    "@sketch-hq/sketch-reuse-suggestions-assistant": "latest"
-  }
-}


### PR DESCRIPTION
Install links should no longer be pinned to an old version.

We want to be installing Assistants as `latest` even to current Sketch Private.