### PR TITLE
fix: make it clearer assistants are added to documents, not globally to sketch

### DIFF
--- a/assistants/naming-conventions/README.md
+++ b/assistants/naming-conventions/README.md
@@ -6,9 +6,9 @@ Naming conventions used by the Sketch design team.
 
 👉 Click
 [here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-naming-conventions-assistant)
-to add to Sketch.
+to add to your Sketch document.
 
-> Or, add to a Sketch release variant:
+> Or, add using a Sketch release variant:
 > [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-naming-conventions-assistant)
 > |
 > [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-naming-conventions-assistant)

--- a/assistants/reuse-suggestions/README.md
+++ b/assistants/reuse-suggestions/README.md
@@ -7,9 +7,9 @@ respectively.
 
 👉 Click
 [here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
-to add to Sketch.
+to add to your Sketch document.
 
-> Or, add to a Sketch release variant:
+> Or, add using a Sketch release variant:
 > [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)
 > |
 > [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-reuse-suggestions-assistant)

--- a/assistants/tidy/README.md
+++ b/assistants/tidy/README.md
@@ -6,9 +6,9 @@ The rules in this Assistant are all focused on keeping your Sketch documents as 
 possible.
 
 👉 Click [here](https://add-sketch-assistant.now.sh/api/main?pkg=@sketch-hq/sketch-tidy-assistant)
-to add to Sketch.
+to add to your Sketch document.
 
-> Or, add to a Sketch release variant:
+> Or, add using a Sketch release variant:
 > [Beta](https://add-sketch-assistant.now.sh/api/main?variant=beta&pkg=@sketch-hq/sketch-tidy-assistant)
 > |
 > [Private](https://add-sketch-assistant.now.sh/api/main?variant=private&pkg=@sketch-hq/sketch-tidy-assistant)


### PR DESCRIPTION
This wording was throwing some of our beta testers for a loop.