### PR TITLE
feat: add public keyword to assistant package.json files

### DIFF
--- a/.changeset/four-turtles-report.md
+++ b/.changeset/four-turtles-report.md
@@ -1,0 +1,7 @@
+---
+'@sketch-hq/sketch-naming-conventions-assistant': patch
+'@sketch-hq/sketch-reuse-suggestions-assistant': patch
+'@sketch-hq/sketch-tidy-assistant': patch
+---
+
+Add `public` keyword to package.json.

--- a/assistants/core/package.json
+++ b/assistants/core/package.json
@@ -11,7 +11,6 @@
     "sketch files",
     "rules only",
     "core rules",
-    "sketch assistant",
     "assistant",
     "design ops"
   ],

--- a/assistants/naming-conventions/package.json
+++ b/assistants/naming-conventions/package.json
@@ -16,6 +16,7 @@
     "sketch",
     "sketch files",
     "sketch assistant",
+    "public",
     "assistant",
     "design ops"
   ],

--- a/assistants/reuse-suggestions/package.json
+++ b/assistants/reuse-suggestions/package.json
@@ -16,6 +16,7 @@
     "sketch",
     "sketch files",
     "sketch assistant",
+    "public",
     "assistant",
     "design ops"
   ],

--- a/assistants/tidy/package.json
+++ b/assistants/tidy/package.json
@@ -16,6 +16,7 @@
     "sketch",
     "sketch files",
     "sketch assistant",
+    "public",
     "assistant",
     "design ops"
   ],


### PR DESCRIPTION
Refs https://github.com/sketch-hq/developer.sketch.com/issues/10

After discussion with @paulozoom it seems like a good idea to use two keywords to signal that an Assistant should be featured on sketch.com: `sketch assistant` and `public`. That way even Assistants that aren't for public consumption on sketch.com can include the meaningful `sketch assistant` keyword and potentially show up in other search results.