### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@master
+        uses: actions/setup-node@main
         with:
           node-version: '12.6.0'
       - name: Yarn Install


### PR DESCRIPTION
Default branches on actions repos have been changed `main`.