### PR TITLE
Fix the Sketch file JSON being mirrored into CLI results potentially causing out-of-memory errors

### DIFF
--- a/.changeset/funny-trees-invite.md
+++ b/.changeset/funny-trees-invite.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-assistant-cli': minor
+---
+
+Fix the Sketch file JSON being mirrored into CLI results potentially causing out-of-memory errors.

--- a/.changeset/yellow-panthers-hope.md
+++ b/.changeset/yellow-panthers-hope.md
@@ -1,0 +1,6 @@
+---
+'@sketch-hq/sketch-assistant-cli': minor
+---
+
+Removed the `--profile` flag, profiling data is now always included in the output when the `--json`
+flag is used.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   },
   "editor.formatOnSave": true,
   "javascript.validate.enable": true,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,10 +78,6 @@ sketch-assistants --json "./path/to/file.sketch"
 When Assistants are installed before a run, they are cached in a temporary folder to make future
 runs faster. Pass this flag to delete the cache folder.
 
-#### `--profile`
-
-Output statistics instead of results.
-
 #### `--workspace`
 
 Optionally supply and overwrite the Assistant workspace configuration within the Sketch file(s) with


### PR DESCRIPTION
Fixes https://github.com/sketch-hq/Sketch/issues/33563

When outputting as JSON using the `--json` flag the CLI was erroneously also including the entire processed Sketch file JSON. This PR fixes things so that property is omitted 😅

In terms of the test cases presented in #33563 making this change resulted in the length of the JSON string reducing 5000x, so I don't think there's any need for further work looking into attempting to chunk up the JSON stringify operation and streaming to stdout.

The reason the processed Sketch file was making its way into the CLI results was to support optionally outputting profile data instead of results. To help with this change I removed the `--profile` flag, and now profile data is consistently included in the output when outputting as JSON (it's a relatively small object, and has a constant size so shouldn't cause any issues).