### PR TITLE
'artboards-layout' and 'artboard-grids' showing non-compliant status when grids and layouts are hidden

### DIFF
--- a/.changeset/sharp-ladybugs-grow.md
+++ b/.changeset/sharp-ladybugs-grow.md
@@ -1,0 +1,6 @@
+---
+'@sketch-hq/sketch-core-assistant': patch
+---
+
+'artboards-layout' and 'artboard-grids' showing non-compliant status when grids and layouts are
+hidden

--- a/assistants/core/src/rules/artboards-grid/__tests__/index.ts
+++ b/assistants/core/src/rules/artboards-grid/__tests__/index.ts
@@ -18,7 +18,7 @@ describe('artboards-grid', () => {
     expect(ruleErrors).toHaveLength(0)
   })
 
-  test('finds violations for artboards with missing grids', async (): Promise<void> => {
+  test('no violations for hidden grids', async (): Promise<void> => {
     expect.assertions(2)
 
     const { ruleErrors, violations } = await testCoreRule(
@@ -31,7 +31,7 @@ describe('artboards-grid', () => {
       },
     )
 
-    expect(violations).toHaveLength(1)
+    expect(violations).toHaveLength(0)
     expect(ruleErrors).toHaveLength(0)
   })
 

--- a/assistants/core/src/rules/artboards-grid/index.ts
+++ b/assistants/core/src/rules/artboards-grid/index.ts
@@ -27,10 +27,16 @@ export const createRule: CreateRuleFunction = (i18n) => {
 
     for (const artboard of utils.objects.artboard) {
       const { grid } = artboard
+
       if (!grid) {
         invalid.push(artboard) // Treat artboards without grid settings as invalid
         continue
       }
+
+      if (!grid.isEnabled) {
+        continue
+      }
+
       // The artboard's grid much precisely match one of the grids defined in the
       // options
       const gridValid = specs

--- a/assistants/core/src/rules/artboards-layout/index.ts
+++ b/assistants/core/src/rules/artboards-layout/index.ts
@@ -82,10 +82,15 @@ export const createRule: CreateRuleFunction = (i18n) => {
 
     for (const artboard of utils.objects.artboard) {
       const { layout } = artboard
-      if (!layout || !layout.isEnabled) {
-        invalid.push(artboard) // Treat artboards without grid settings as invalid
+      if (!layout) {
+        invalid.push(artboard) // Treat artboards without layout as invalid
         continue
       }
+
+      if (!layout.isEnabled) {
+        continue
+      }
+
       // The artboard's layout much match one of the layouts defined in the options
       const columnsValid = specs
         .map((spec) => {


### PR DESCRIPTION
- Add two `continue` in case a grid on a artboard is hidden (`isEnabled` is false).
- Update a test that previously checked for "missing" configurations