### PR TITLE
Add API documentation

### DIFF
--- a/.changeset/mighty-mails-count.md
+++ b/.changeset/mighty-mails-count.md
@@ -1,0 +1,5 @@
+---
+'@sketch-hq/sketch-assistant-utils': patch
+---
+
+Add documentation for buildAssistantConfigSchema

--- a/packages/utils/src/assistant-config-schema/index.ts
+++ b/packages/utils/src/assistant-config-schema/index.ts
@@ -26,6 +26,15 @@ const applyRuleConfig = (ops: JSONSchemaProps, config: RuleConfig): JSONSchemaPr
   }, {})
 }
 
+/**
+ * Builds the JSON Schema for the configuration accepted by the given
+ * assistant. The schema is augmented with assistant's configuration,
+ * meaning the options set in the configuration are used as default values
+ * for the corresponding properties.
+ *
+ * @param assistant Assistant to generate the configuration schema from
+ * @returns JSON Schema describing the assistant's configuration shape
+ */
 const buildAssistantConfigSchema: AssistantConfigSchemaCreator = (assistant) => {
   return {
     type: 'object',


### PR DESCRIPTION
Usage information was missing for `buildAssistantConfigSchema`